### PR TITLE
Fix order of freeing Detector resources to avoid segfault

### DIFF
--- a/dt_apriltags/apriltags.py
+++ b/dt_apriltags/apriltags.py
@@ -316,6 +316,10 @@ class Detector(object):
 
     def __del__(self):
         if self.tag_detector_ptr is not None:
+            # destroy the detector
+            self.libc.apriltag_detector_destroy.restype = None
+            self.libc.apriltag_detector_destroy(self.tag_detector_ptr)
+
             # destroy the tag families
             for family, tf in self.tag_families.items():
                 if 'tag16h5' == family:
@@ -342,10 +346,6 @@ class Detector(object):
                 elif 'tagStandard52h13' == family:
                     self.libc.tagStandard52h13_destroy.restype = None
                     self.libc.tagStandard52h13_destroy(tf)
-
-            # destroy the detector
-            self.libc.apriltag_detector_destroy.restype = None
-            self.libc.apriltag_detector_destroy(self.tag_detector_ptr)
 
     def detect(self, img, estimate_tag_pose=False, camera_params=None, tag_size=None):
         """


### PR DESCRIPTION
When deleting a 2nd Detector in a program, the code segfaults. This can be fixed by releasing the detector first, then the tag family as in the official example:  https://github.com/AprilRobotics/apriltag/blob/master/example/opencv_demo.cc