### PR TITLE
Build extension using Python build tooling

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include dt_apriltags/libapriltag.so
+include dt_apriltags/libapriltag.dylib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "apriltags"
+name = "dt-apriltags"
 version = "0.0.0"
 description = "apriltags"
 authors = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "numpy", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[tool.poetry]
+name = "apriltags"
+version = "0.0.0"
+description = "apriltags"
+authors = []
+readme = "README.md"
+repository = "https://github.com/terraform-industries/lib-dt-apriltags"
+
 [build-system]
 requires = ["setuptools>=40.8.0", "numpy", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from xml.dom import minidom
 
-from setuptools import setup
+import subprocess
+import os
+import sys
+import shutil
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
 
 POSTFIX = ''
 
@@ -24,6 +30,34 @@ GitHub `repository <https://github.com/duckietown/dt-apriltags>`_.
 
 """
 
+class CMakeExtension(Extension):
+    def __init__(self, name, cmake_lists_dir='.', **kwa):
+        Extension.__init__(self, name, sources=[], **kwa)
+        self.cmake_lists_dir = os.path.abspath(cmake_lists_dir)
+
+class CMakeBuildExtension(build_ext):
+    def build_extensions(self):
+        # Ensure that CMake is present and working
+        try:
+            subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError('Cannot find CMake executable')
+
+        for ext in self.extensions:
+            extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+
+            if not os.path.exists(self.build_temp):
+                os.makedirs(self.build_temp)
+
+            subprocess.check_call(['cmake', '.'], cwd=ext.cmake_lists_dir)
+            subprocess.check_call(['make'], cwd=ext.cmake_lists_dir)
+
+            try:
+                shutil.copyfile(os.path.join(ext.cmake_lists_dir, "libapriltag.so"), os.path.join(extdir, 'dt_apriltags', "libapriltag.so"))
+            except FileNotFoundError:
+                shutil.copyfile(os.path.join(ext.cmake_lists_dir, "libapriltag.dylib"), os.path.join(extdir, 'dt_apriltags', "libapriltag.dylib"))
+
+
 setup(
     name='dt_apriltags',
     version=version+POSTFIX,
@@ -33,5 +67,7 @@ setup(
     install_requires=['numpy'],
     packages=['dt_apriltags'],
     long_description=description,
+    ext_modules = [CMakeExtension("apriltag", "apriltags")],
+    cmdclass = {'build_ext': CMakeBuildExtension},
     include_package_data=True
 )


### PR DESCRIPTION
This allows you to build the extension without Docker. You can just run pip wheel ./ to build the extension locally. This also allows you to use the apriltag extension from git with poetry.

It also now builds on macOS